### PR TITLE
Moved to readable-stream. Adds support for node@0.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: node_js
 node_js:
   - '0.11'
   - '0.10'
+  - '0.8'

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@
  * Module dependencies.
  */
 
-var Readable = require('stream').Readable;
+var Readable = require('readable-stream').Readable;
 var util = require('util');
 
 module.exports = ContentStream;

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     }
   },
   "dependencies": {
-
+    "readable-stream": "~1.0.33-1"
   },
   "devDependencies": {
     "autod": "*",
@@ -38,7 +38,7 @@
     "contentstream", "readable", "readstream", "stream", "stream2", "stream3"
   ],
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">= 0.8.0"
   },
   "author": "fengmk2 <fengmk2@gmail.com> (http://fengmk2.github.com)",
   "license": "MIT"


### PR DESCRIPTION
I would love to use this module but it doesn't currently support `node@0.8` which I am currently a proponent of until `node@0.12` comes out. To fix that, I have moved over to `readable-stream` which is the user-land version of `stream` in `node@0.10`. In this PR:
- Added `node@0.8` testing into Travis CI
- Downgraded `node` engine to `node>=0.8`
- Added dependency to `readable-stream`
- Moved from `core's stream` to `readable-stream`

Relevant links:

https://github.com/isaacs/readable-stream

http://r.va.gg/2014/06/why-i-dont-use-nodes-core-stream-module.html
